### PR TITLE
Changing german URL to a working one

### DIFF
--- a/functions/getURL.js
+++ b/functions/getURL.js
@@ -33,7 +33,7 @@ exports.regionURL = function (region) {
 
         case "de":
         case "german":
-            id = "srv7.akinator.com:9145";
+            id = "srv7.akinator.com:9241";
             break;
 
         case "es":


### PR DESCRIPTION
It seems like the old server for Germany is not in use anymore (Not responding to requests). This new server is working.